### PR TITLE
Reduce size of images

### DIFF
--- a/OutfitGenerator.xcodeproj/project.pbxproj
+++ b/OutfitGenerator.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		967328F228FA5C2600F7D909 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 967328F028FA5C2600F7D909 /* LaunchScreen.storyboard */; };
 		967ADA9428FCCB5B00942FF1 /* BackgroundRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967ADA9328FCCB5B00942FF1 /* BackgroundRemovalTests.swift */; };
 		9694FA75295F82230016D367 /* BackgroundRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9694FA74295F82230016D367 /* BackgroundRemoval.swift */; };
+		96A93A1D2A01F46500A3D374 /* ImageScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A93A1C2A01F46500A3D374 /* ImageScale.swift */; };
+		96A93A1F2A020A2D00A3D374 /* ImageScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A93A1E2A020A2D00A3D374 /* ImageScaleTests.swift */; };
 		96E3447229A5BA50000131B1 /* ClothingCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E3447129A5BA50000131B1 /* ClothingCollectionReusableView.swift */; };
 		96F0E5AF291CBBBC00B5BB3F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 96F0E5AE291CBBBB00B5BB3F /* GoogleService-Info.plist */; };
 		BC302B78A1602231CDA09574 /* Pods_OutfitGenerator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1C01469FAA1C35AE26E434C /* Pods_OutfitGenerator.framework */; };
@@ -48,9 +50,11 @@
 		967328EE28FA5C2600F7D909 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		967328F128FA5C2600F7D909 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		967328F328FA5C2600F7D909 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		967ADA9128FCCB5B00942FF1 /* BackgroundRemovalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BackgroundRemovalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		967ADA9128FCCB5B00942FF1 /* OutfitGeneratorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OutfitGeneratorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		967ADA9328FCCB5B00942FF1 /* BackgroundRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRemovalTests.swift; sourceTree = "<group>"; };
 		9694FA74295F82230016D367 /* BackgroundRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRemoval.swift; sourceTree = "<group>"; };
+		96A93A1C2A01F46500A3D374 /* ImageScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScale.swift; sourceTree = "<group>"; };
+		96A93A1E2A020A2D00A3D374 /* ImageScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScaleTests.swift; sourceTree = "<group>"; };
 		96E3447129A5BA50000131B1 /* ClothingCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothingCollectionReusableView.swift; sourceTree = "<group>"; };
 		96F0E5AE291CBBBB00B5BB3F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		EC30F54E629E0E4ED0444460 /* Pods_BackgroundRemovalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BackgroundRemovalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,7 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				967328E228FA5C2400F7D909 /* OutfitGenerator.app */,
-				967ADA9128FCCB5B00942FF1 /* BackgroundRemovalTests.xctest */,
+				967ADA9128FCCB5B00942FF1 /* OutfitGeneratorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -125,6 +129,7 @@
 		967ADA9228FCCB5B00942FF1 /* OutfitGeneratorTests */ = {
 			isa = PBXGroup;
 			children = (
+				96A93A1E2A020A2D00A3D374 /* ImageScaleTests.swift */,
 				967ADA9328FCCB5B00942FF1 /* BackgroundRemovalTests.swift */,
 			);
 			path = OutfitGeneratorTests;
@@ -134,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				9694FA74295F82230016D367 /* BackgroundRemoval.swift */,
+				96A93A1C2A01F46500A3D374 /* ImageScale.swift */,
 				961A0B8F29E2632D005991B9 /* Queue.swift */,
 			);
 			path = Models;
@@ -191,9 +197,9 @@
 			productReference = 967328E228FA5C2400F7D909 /* OutfitGenerator.app */;
 			productType = "com.apple.product-type.application";
 		};
-		967ADA9028FCCB5B00942FF1 /* BackgroundRemovalTests */ = {
+		967ADA9028FCCB5B00942FF1 /* OutfitGeneratorTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 967ADA9928FCCB5B00942FF1 /* Build configuration list for PBXNativeTarget "BackgroundRemovalTests" */;
+			buildConfigurationList = 967ADA9928FCCB5B00942FF1 /* Build configuration list for PBXNativeTarget "OutfitGeneratorTests" */;
 			buildPhases = (
 				89434F713DC6277FFFFC1076 /* [CP] Check Pods Manifest.lock */,
 				967ADA8D28FCCB5B00942FF1 /* Sources */,
@@ -205,9 +211,9 @@
 			dependencies = (
 				967ADA9628FCCB5B00942FF1 /* PBXTargetDependency */,
 			);
-			name = BackgroundRemovalTests;
+			name = OutfitGeneratorTests;
 			productName = OutfitGeneratorTests;
-			productReference = 967ADA9128FCCB5B00942FF1 /* BackgroundRemovalTests.xctest */;
+			productReference = 967ADA9128FCCB5B00942FF1 /* OutfitGeneratorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -243,7 +249,7 @@
 			projectRoot = "";
 			targets = (
 				967328E128FA5C2400F7D909 /* OutfitGenerator */,
-				967ADA9028FCCB5B00942FF1 /* BackgroundRemovalTests */,
+				967ADA9028FCCB5B00942FF1 /* OutfitGeneratorTests */,
 			);
 		};
 /* End PBXProject section */
@@ -343,6 +349,7 @@
 				967328E628FA5C2400F7D909 /* AppDelegate.swift in Sources */,
 				9621ABC02995E69D00B77A6B /* ClothingCollectionViewCell.swift in Sources */,
 				967328E828FA5C2400F7D909 /* SceneDelegate.swift in Sources */,
+				96A93A1D2A01F46500A3D374 /* ImageScale.swift in Sources */,
 				9694FA75295F82230016D367 /* BackgroundRemoval.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -351,6 +358,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96A93A1F2A020A2D00A3D374 /* ImageScaleTests.swift in Sources */,
 				967ADA9428FCCB5B00942FF1 /* BackgroundRemovalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -614,7 +622,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		967ADA9928FCCB5B00942FF1 /* Build configuration list for PBXNativeTarget "BackgroundRemovalTests" */ = {
+		967ADA9928FCCB5B00942FF1 /* Build configuration list for PBXNativeTarget "OutfitGeneratorTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				967ADA9728FCCB5B00942FF1 /* Debug */,

--- a/OutfitGenerator.xcodeproj/xcshareddata/xcschemes/OutfitGenerator.xcscheme
+++ b/OutfitGenerator.xcodeproj/xcshareddata/xcschemes/OutfitGenerator.xcscheme
@@ -34,8 +34,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "967ADA9028FCCB5B00942FF1"
-               BuildableName = "BackgroundRemovalTests.xctest"
-               BlueprintName = "BackgroundRemovalTests"
+               BuildableName = "OutfitGeneratorTests.xctest"
+               BlueprintName = "OutfitGeneratorTests"
                ReferencedContainer = "container:OutfitGenerator.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/OutfitGenerator/Controllers/ViewController.swift
+++ b/OutfitGenerator/Controllers/ViewController.swift
@@ -172,7 +172,7 @@ extension ViewController: UIImagePickerControllerDelegate, UINavigationControlle
         }
         
         let backgroundRemoval = BackgroundRemoval()
-        backgroundRemoval.removeBackground(for: image) { (segmentedImageData) in
+        backgroundRemoval.removeBackground(for: image.resize(by: 0.1)) { (segmentedImageData) in
             self.uploadImage(segmentedImageData!)
         }
     }

--- a/OutfitGenerator/Controllers/ViewController.swift
+++ b/OutfitGenerator/Controllers/ViewController.swift
@@ -87,7 +87,7 @@ class ViewController: UIViewController {
     // Uploads images to Firebase Cloud Storage.
     private func uploadImage(_ imageData: NSData) {
         // Each uploaded image gets a unique ID.
-        let imagesReference = storageReference.child("images/\(UUID().uuidString).png")
+        let imagesReference = storageReference.child("images/\(UUID().uuidString).jpeg")
         
         imagesReference.putData(imageData as Data, metadata: nil) { (_, error) in
             guard error == nil else {

--- a/OutfitGenerator/Models/BackgroundRemoval.swift
+++ b/OutfitGenerator/Models/BackgroundRemoval.swift
@@ -18,7 +18,7 @@ struct BackgroundRemoval {
         let mutableData = NSMutableData()
         mutableData.appendString("--\(boundary)\r\n")
         mutableData.appendString("Content-Disposition: form-data; name=\"image\"\r\n\r\n")
-        let imageData = image.pngData()!
+        let imageData = image.jpegData(compressionQuality: 0.7)!
         mutableData.append(imageData)
         mutableData.appendString("\r\n")
         mutableData.appendString("--\(boundary)--")

--- a/OutfitGenerator/Models/ImageScale.swift
+++ b/OutfitGenerator/Models/ImageScale.swift
@@ -1,0 +1,21 @@
+//
+//  ImageScale.swift
+//  OutfitGenerator
+//
+//  Created by Jason on 5/2/23.
+//
+
+import Foundation
+import UIKit
+
+extension UIImage {
+    func resize(by scale: CGFloat) -> UIImage {
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+
+        let image = UIGraphicsImageRenderer(size: newSize).image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+        
+        return image.withRenderingMode(renderingMode)
+    }
+}

--- a/OutfitGeneratorTests/ImageScaleTests.swift
+++ b/OutfitGeneratorTests/ImageScaleTests.swift
@@ -1,0 +1,35 @@
+//
+//  ImageScaleTests.swift
+//  OutfitGeneratorTests
+//
+//  Created by Jason on 5/2/23.
+//
+
+import XCTest
+@testable import OutfitGenerator
+
+final class ImageScaleTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+    
+    func testImageScaleReducesImageSize() throws {
+        // Given.
+        let imageSize = CGSize(width: 50, height: 50)
+        UIGraphicsBeginImageContext(imageSize)
+        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        
+        // When.
+        let scaledImage = image.resize(by: 0.5)
+        
+        // Then.
+        XCTAssertLessThan(scaledImage.size.height * scaledImage.size.width, image.size.height * image.size.width)
+    }
+
+}

--- a/OutfitGeneratorTests/ImageScaleTests.swift
+++ b/OutfitGeneratorTests/ImageScaleTests.swift
@@ -10,26 +10,44 @@ import XCTest
 
 final class ImageScaleTests: XCTestCase {
 
+    var sut: UIImage!
+    
     override func setUpWithError() throws {
         try super.setUpWithError()
+        sut = UIImage()
     }
 
     override func tearDownWithError() throws {
+        sut = nil
         try super.tearDownWithError()
     }
     
-    func testImageScaleReducesImageSize() throws {
+    func testImageScaleCanReduceImageSize() throws {
         // Given.
         let imageSize = CGSize(width: 50, height: 50)
         UIGraphicsBeginImageContext(imageSize)
-        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        sut = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         
         // When.
-        let scaledImage = image.resize(by: 0.5)
+        let scaledImage = sut.resize(by: 0.5)
         
         // Then.
-        XCTAssertLessThan(scaledImage.size.height * scaledImage.size.width, image.size.height * image.size.width)
+        XCTAssertLessThan(scaledImage.size.height * scaledImage.size.width, sut.size.height * sut.size.width)
+    }
+    
+    func testImageScaleCanIncreaseImageSize() throws {
+        // Given.
+        let imageSize = CGSize(width: 50, height: 50)
+        UIGraphicsBeginImageContext(imageSize)
+        sut = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        
+        // When.
+        let scaledImage = sut.resize(by: 1.5)
+        
+        // Then.
+        XCTAssertGreaterThan(scaledImage.size.height * scaledImage.size.width, sut.size.height * sut.size.width)
     }
 
 }

--- a/OutfitGeneratorTests/ImageScaleTests.swift
+++ b/OutfitGeneratorTests/ImageScaleTests.swift
@@ -49,5 +49,18 @@ final class ImageScaleTests: XCTestCase {
         // Then.
         XCTAssertGreaterThan(scaledImage.size.height * scaledImage.size.width, sut.size.height * sut.size.width)
     }
-
+    
+    func testScaledImageHasSameAspectRatio() throws {
+        // Given.
+        let imageSize = CGSize(width: 50, height: 50)
+        UIGraphicsBeginImageContext(imageSize)
+        sut = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        
+        // When.
+        let scaledImage = sut.resize(by: 0.5)
+        
+        // Then.
+        XCTAssertEqual(scaledImage.size.width / scaledImage.size.height, sut.size.width / sut.size.height)
+    }
 }


### PR DESCRIPTION
Images use jpeg and are scaled down. This makes it faster to process, upload, and download images.